### PR TITLE
Renovate tweaks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["cargo", "github-actions", "dockerfile", "docker-compose"],
+  "enabledManagers": ["cargo", "github-actions", "dockerfile"],
   "dependencyDashboard": true,
+  "pinDigests": true,
+  "minimumReleaseAge": "7 days",
+  "prConcurrentLimit": 5,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on the first day of the month"]
+  },
   "packageRules": [
     {
       "groupName": "cargo minor",
@@ -15,7 +22,7 @@
     },
     {
       "groupName": "docker minor",
-      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ]


### PR DESCRIPTION

## 📔 Objective

- Removed docker-compose from enabledManagers
- Added pinDigests: true
- Added minimumReleaseAge: "7 days" — Renovate will detect new versions immediately but won't open a PR until they're 7 days old
- Added prConcurrentLimit: 5
- Added lockFileMaintenance on a monthly schedule (Cargo.lock refresh)
- Updated the docker minor group rule to only reference dockerfile since docker-compose was removed

## ⏰ Reminders before review

- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- CI builds passed
- Updated any necessary documentation

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
